### PR TITLE
Added the WixUtilExtension to the candle command

### DIFF
--- a/wix/index.go
+++ b/wix/index.go
@@ -14,7 +14,7 @@ func GenerateCmd(wixFile *manifest.WixManifest, templates []string, msiOutFile, 
 
 	cmd := ""
 
-	cmd += filepath.Join(path, "candle")
+	cmd += filepath.Join(path, "candle") + " -ext WixUtilExtension"
 	if arch != "" {
 		if arch == "386" {
 			arch = "x86"


### PR DESCRIPTION
Added the `-ext WixUtilExtension` to the `candle` command in order to use extensions in the wix file.